### PR TITLE
fix: Correct export name from Home to HomePage in HomePage component

### DIFF
--- a/src/pages/home/HomePage.jsx
+++ b/src/pages/home/HomePage.jsx
@@ -20,4 +20,4 @@ function HomePage() {
   );
 }
 
-export default Home;
+export default HomePage;


### PR DESCRIPTION
This pull request includes a small change to the `HomePage` component in the `src/pages/home/HomePage.jsx` file. The change updates the default export from `Home` to `HomePage` to match the component's function name.

* [`src/pages/home/HomePage.jsx`](diffhunk://#diff-a22a7e74128242131d6eadcf1d974e3a34d2338347657d741aa3382d3f69caf4L23-R23): Updated the default export from `Home` to `HomePage`.