### PR TITLE
feat: Add Vercel configuration for URL rewrites

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
This pull request introduces a configuration change to the `vercel.json` file to enable URL rewriting for a smoother user experience.

Routing configuration:

* [`vercel.json`](diffhunk://#diff-a3265310f552fb66876e8bfe8809737e59e5ba946bdf39138b44d9baf4e21240R1-R3): Added a rewrite rule that redirects all incoming requests (`/(.*)`) to `index.html`. This is typically used in single-page applications to handle routing on the client side.